### PR TITLE
change import paths; fix `go get`

### DIFF
--- a/gokogiri.go
+++ b/gokogiri.go
@@ -1,8 +1,8 @@
 package gokogiri
 
 import (
-	"gokogiri/html"
-	"gokogiri/xml"
+	"./html"
+	"./xml"
 )
 
 func ParseHtml(content []byte) (doc *html.HtmlDocument, err error) {

--- a/gokogiri_test.go
+++ b/gokogiri_test.go
@@ -1,7 +1,7 @@
 package gokogiri
 
 import (
-	"gokogiri/help"
+	"help"
 	"testing"
 )
 

--- a/html/document.go
+++ b/html/document.go
@@ -12,8 +12,8 @@ import "C"
 
 import (
 	"errors"
-	. "gokogiri/util"
-	"gokogiri/xml"
+	. "../util"
+	"../xml"
 	//"runtime"
 	"unsafe"
 )

--- a/html/fragment.go
+++ b/html/fragment.go
@@ -5,8 +5,8 @@ import "C"
 import (
 	"bytes"
 	"errors"
-	. "gokogiri/util"
-	"gokogiri/xml"
+	. "../util"
+	"../xml"
 	"unsafe"
 )
 

--- a/html/utils_test.go
+++ b/html/utils_test.go
@@ -2,7 +2,7 @@ package html
 
 import (
 	"fmt"
-	"gokogiri/help"
+	"../help"
 	"io/ioutil"
 	"path/filepath"
 	"strings"

--- a/xml/document.go
+++ b/xml/document.go
@@ -10,8 +10,8 @@ import "C"
 
 import (
 	"errors"
-	. "gokogiri/util"
-	"gokogiri/xpath"
+	. "../util"
+	"../xpath"
 	//"runtime"
 	"unsafe"
 )

--- a/xml/fragment.go
+++ b/xml/fragment.go
@@ -4,7 +4,7 @@ package xml
 import "C"
 import (
 	"errors"
-	. "gokogiri/util"
+	. "../util"
 	"unsafe"
 )
 

--- a/xml/node.go
+++ b/xml/node.go
@@ -9,8 +9,8 @@ import "time"
 import (
 	"errors"
 	"fmt"
-	. "gokogiri/util"
-	"gokogiri/xpath"
+	. "../util"
+	"../xpath"
 	"unsafe"
 )
 

--- a/xml/utils_test.go
+++ b/xml/utils_test.go
@@ -3,7 +3,7 @@ package xml
 import (
 	"errors"
 	"fmt"
-	"gokogiri/help"
+	"../help"
 	"io/ioutil"
 	"path/filepath"
 	"strings"

--- a/xpath/expression.go
+++ b/xpath/expression.go
@@ -32,7 +32,7 @@ char *check_xpath_syntax(const char *xpath) {
 */
 import "C"
 import "unsafe"
-import . "gokogiri/util"
+import . "../util"
 //import "runtime"
 import "errors"
 

--- a/xpath/util_test.go
+++ b/xpath/util_test.go
@@ -1,7 +1,7 @@
 package xpath
 
 import "testing"
-import "gokogiri/help"
+import "../help"
 
 func CheckXmlMemoryLeaks(t *testing.T) {
 	help.LibxmlCleanUpParser()

--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -15,7 +15,7 @@ import "C"
 
 import "time"
 import "unsafe"
-import . "gokogiri/util"
+import . "../util"
 import "runtime"
 import "errors"
 


### PR DESCRIPTION
Currently this package refers to imports as a path `gokogiri/...` that doesn't exist. This makes it imposible to install as any other path (ie: "github.com/moovweb/gokogiri"). I think this can be resolved by making all local references to gokogiri components as relative imports.

ie: in `gokogiri/html/document.go` the reference to `util` should be `"../util"`

```
~$ pkg-config --cflags libxml-2.0 libxml-2.0
-I/usr/include/libxml2  
~$ go get github.com/moovweb/gokogiri
package gokogiri/html: unrecognized import path "gokogiri/html"
package gokogiri/xml: unrecognized import path "gokogiri/xml"
$ go get github.com/moovweb/gokogiri/html
package gokogiri/util: unrecognized import path "gokogiri/util"
package gokogiri/xml: unrecognized import path "gokogiri/xml"
```
