### PR TITLE
SetNamespace

### DIFF
--- a/xml/node.go
+++ b/xml/node.go
@@ -140,6 +140,7 @@ type Node interface {
 	InnerHtml() string
 
 	RecursivelyRemoveNamespaces() error
+	SetNamespace(string, string)
 }
 
 //run out of memory
@@ -865,4 +866,19 @@ func (xmlNode *XmlNode) RecursivelyRemoveNamespaces() (err error) {
 		}
 	}
 	return
+}
+
+func (xmlNode *XmlNode) SetNamespace(prefix, href string) {
+	if xmlNode.NodeType() != XML_ELEMENT_NODE {
+		return
+	}
+
+	prefixBytes := GetCString([]byte(prefix))
+	prefixPtr := unsafe.Pointer(&prefixBytes[0])
+
+	hrefBytes := GetCString([]byte(href))
+	hrefPtr := unsafe.Pointer(&hrefBytes[0])
+
+	ns := C.xmlNewNs(xmlNode.Ptr, (*C.xmlChar)(hrefPtr), (*C.xmlChar)(prefixPtr))
+	C.xmlSetNs(xmlNode.Ptr, ns)
 }

--- a/xml/node_test.go
+++ b/xml/node_test.go
@@ -233,3 +233,12 @@ func TestInnerWithAttributes(t *testing.T) {
 
 	RunTest(t, "node", "inner_with_attributes", testLogic)
 }
+
+func TestSetNamespace(t *testing.T) {
+	testLogic := func(t *testing.T, doc *XmlDocument) {
+		root := doc.Root()
+		root.SetNamespace("foo", "bar")
+	}
+
+	RunTest(t, "node", "set_namespace", testLogic)
+}

--- a/xml/tests/node/set_namespace/input.txt
+++ b/xml/tests/node/set_namespace/input.txt
@@ -1,0 +1,1 @@
+<foo><bar1/><bar2/></foo>

--- a/xml/tests/node/set_namespace/output.txt
+++ b/xml/tests/node/set_namespace/output.txt
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<foo:foo xmlns:foo="bar">
+  <bar1/>
+  <bar2/>
+</foo:foo>


### PR DESCRIPTION
This helps parse and search XMPP stanzas like <stream:error ...> that arrive without a namespace.
