### PR TITLE
xmlRemoveDefaultNamespace

### DIFF
--- a/xml/document_test.go
+++ b/xml/document_test.go
@@ -233,7 +233,7 @@ func BenchmarkDocOutputToBuffer(b *testing.B) {
 
 }
 
-func TestRemoveNamespace(t *testing.T) {
+func TestRemoveNamespaces(t *testing.T) {
 	xml := "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Body><m:setPresence xmlns:m=\"http://schemas.microsoft.com/winrtc/2002/11/sip\"><m:presentity m:uri=\"test\"><m:availability m:aggregate=\"300\" m:description=\"online\"/><m:activity m:aggregate=\"400\" m:description=\"Active\"/><deviceName xmlns=\"http://schemas.microsoft.com/2002/09/sip/client/presence\" name=\"WIN-0DDABKC1UI8\"/></m:presentity></m:setPresence></SOAP-ENV:Body></SOAP-ENV:Envelope>"
 	xml_no_namespace := "<Envelope><Body><setPresence><presentity uri=\"test\"><availability aggregate=\"300\" description=\"online\"/><activity aggregate=\"400\" description=\"Active\"/><deviceName name=\"WIN-0DDABKC1UI8\"/></presentity></setPresence></Body></Envelope>"
 
@@ -245,5 +245,36 @@ func TestRemoveNamespace(t *testing.T) {
 	output_no_namespace := fmt.Sprintf("%v", doc2)
 	if output != output_no_namespace {
 		t.Errorf("Xml namespaces not removed!")
+	}
+}
+
+func TestRemoveDefaultNamespace(t *testing.T) {
+	xml := `
+<body xmlns="http://jabber.org/protocol/httpbind" xmlns:stream="http://etherx.jabber.org/streams" to="127.0.0.1" rid="3" sid="0acad5262d995374">
+  <iq id="2" type="get" from="">
+    <query xmlns="jabber:iq:auth">
+      <username>xyz</username>
+    </query>
+  </iq>
+</body>
+`
+
+	xml_no_namespace := `
+<body xmlns:stream="http://etherx.jabber.org/streams" to="127.0.0.1" rid="3" sid="0acad5262d995374">
+  <iq id="2" type="get" from="">
+    <query xmlns="jabber:iq:auth">
+      <username>xyz</username>
+    </query>
+  </iq>
+</body>
+`
+	doc, _ := Parse([]byte(xml), DefaultEncodingBytes, nil, DefaultParseOption, DefaultEncodingBytes)
+	doc.Root().RemoveDefaultNamespace()
+	doc2, _ := Parse([]byte(xml_no_namespace), DefaultEncodingBytes, nil, DefaultParseOption, DefaultEncodingBytes)
+
+	output := fmt.Sprintf("%v", doc)
+	output_no_namespace := fmt.Sprintf("%v", doc2)
+	if output != output_no_namespace {
+		t.Errorf("Default namespace not removed!")
 	}
 }

--- a/xml/helper.c
+++ b/xml/helper.c
@@ -144,3 +144,52 @@ int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options) {
 	return xmlSaveClose(savectx);
 }
 
+void removeNamespace(xmlNs **source, xmlNs *target) {
+    xmlNs *ns, *prevns = NULL;
+
+    for (ns = *source; ns; ns = ns->next) {
+        if (ns == target) {
+            if (!prevns) {
+                // we are the first element
+                *source = ns->next;
+            } else {
+                prevns->next = ns->next;
+            }
+
+            break;
+        }
+
+        prevns = ns;
+    }
+}
+
+void removeDefaultNamespace(xmlNs *ns, xmlNode *node) {
+    removeNamespace(&node->nsDef, ns);
+
+    xmlAttr *attr;
+
+    for (attr = node->properties; attr; attr = attr->next) {
+        if (!attr->ns)
+            continue;
+
+        removeNamespace(&attr->ns, ns);
+    }
+
+    if (node->ns == ns)
+    	node->ns = NULL;
+
+    xmlNode *child;
+
+    for (child = xmlFirstElementChild(node); child; child = xmlNextElementSibling(child)) {
+        removeDefaultNamespace(ns, child);
+    }
+}
+
+void xmlRemoveDefaultNamespace(xmlNode *node) {
+    if (node->ns && node->ns->prefix) {
+        // not a default namespace
+        return;
+    }
+
+    removeDefaultNamespace(node->ns, node);
+}

--- a/xml/helper.h
+++ b/xml/helper.h
@@ -13,6 +13,7 @@ xmlDoc* xmlParse(void *buffer, int buffer_len, void *url, void *encoding, int op
 xmlNode* xmlParseFragment(void* doc, void *buffer, int buffer_len, void *url, int options, void *error_buffer, int error_buffer_len);
 xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *url, void *encoding, int options, void *error_buffer, int error_buffer_len);
 int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options);
+void xmlRemoveDefaultNamespace(xmlNode *node);
 
 void xmlSetContent(void *gonode, void *node, void *content);
 

--- a/xml/node.go
+++ b/xml/node.go
@@ -142,6 +142,7 @@ type Node interface {
 
 	RecursivelyRemoveNamespaces() error
 	SetNamespace(string, string)
+	RemoveDefaultNamespace()
 }
 
 //run out of memory
@@ -871,6 +872,11 @@ func (xmlNode *XmlNode) RecursivelyRemoveNamespaces() (err error) {
 		}
 	}
 	return
+}
+
+func (xmlNode *XmlNode) RemoveDefaultNamespace() {
+	nodePtr := xmlNode.Ptr
+	C.xmlRemoveDefaultNamespace(nodePtr)
 }
 
 func (xmlNode *XmlNode) SetNamespace(prefix, href string) {


### PR DESCRIPTION
A node extracted from a source document will inherit the default namespace of that document and carry it to the target. 

It's convenient to be able to remove the default namespace from the node before copying, e.g. when extracting the `<iq/>` node here

```
<body xmlns="http://jabber.org/protocol/httpbind" 
        xmlns:stream="http://etherx.jabber.org/streams" 
        to="127.0.0.1" 
        rid="3" 
        sid="0acad5262d995374">
  <iq id="2" type="get" from="">
    <query xmlns="jabber:iq:auth">
      <username>xyz</username>
    </query>
  </iq>
</body>
```
