### PR TITLE
Add Namespace() to Node interface

### DIFF
--- a/xml/node.go
+++ b/xml/node.go
@@ -141,6 +141,7 @@ type Node interface {
 	InnerHtml() string
 
 	RecursivelyRemoveNamespaces() error
+	Namespace() (string)
 	SetNamespace(string, string)
 	RemoveDefaultNamespace()
 }
@@ -566,6 +567,14 @@ func (xmlNode *XmlNode) Name() (name string) {
 	if xmlNode.Ptr.name != nil {
 		p := unsafe.Pointer(xmlNode.Ptr.name)
 		name = C.GoString((*C.char)(p))
+	}
+	return
+}
+
+func (xmlNode *XmlNode) Namespace() (href string) {
+	if xmlNode.Ptr.ns != nil {
+		p := unsafe.Pointer(xmlNode.Ptr.ns.href)
+		href = C.GoString((*C.char)(p))
 	}
 	return
 }


### PR DESCRIPTION
While the interface has a "SetNamespace" function, it oddly lacks a getter for the namespace value. This pull request addresses this oversight.

I've chosen to only return the href (rather than exposing a XmlNs struct) as the prefix declaration is only relevant when writing XML.
