### PR TITLE
Feature: allow to create an XML document from scratch

### DIFF
--- a/xml/document.go
+++ b/xml/document.go
@@ -36,6 +36,7 @@ type Document interface {
 	Free()
 	String() string
 	Root() *ElementNode
+	SetRoot(*ElementNode)
 	NodeById(string) *ElementNode
 	BookkeepFragment(*DocumentFragment)
 
@@ -219,6 +220,10 @@ func (document *XmlDocument) Root() (element *ElementNode) {
 		element = NewNode(unsafe.Pointer(nodePtr), document).(*ElementNode)
 	}
 	return
+}
+
+func (document *XmlDocument) SetRoot(element *ElementNode) {
+	C.xmlDocSetRootElement(document.Ptr, element.Ptr)
 }
 
 // Get an element node by the value of its ID attribute. By convention this attribute

--- a/xml/document_test.go
+++ b/xml/document_test.go
@@ -80,6 +80,29 @@ func TestBufferedDocuments(t *testing.T) {
 	}
 }
 
+func TestCreateRootDocument(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	offset := "\t"
+	expected := "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<root/>\n"
+	
+	defer CheckXmlMemoryLeaks(t)
+
+	buffer := make([]byte, 500000)
+
+	doc := CreateEmptyDocument(DefaultEncodingBytes, DefaultEncodingBytes)
+	envelope := doc.CreateElementNode("root")
+	doc.SetRoot(envelope)
+
+	if string(doc.ToBuffer(buffer)) != expected {
+		formattedOutput := offset + strings.Join(strings.Split("["+doc.String()+"]", "\n"), "\n"+offset)
+		formattedExpectedOutput := offset + strings.Join(strings.Split("["+expected+"]", "\n"), "\n"+offset)
+		t.Errorf("Test failed: %v-- Got --\n%v\n%v-- Expected --\n%v\n", offset, formattedOutput, offset, formattedExpectedOutput) 
+	}
+	doc.Free()
+}
+
 func RunParseDocumentWithBufferTest(t *testing.T, name string) (error *string) {
 	var errorMessage string
 	offset := "\t"


### PR DESCRIPTION
It wasn't possible to set the root XML element, so it was only possible
to create new XML document by parsing an existing content.

This patch allows to build an XML document tree programatically:
    doc := xml.CreateEmptyDocument(xml.DefaultEncodingBytes, xml.DefaultEncodingBytes)
    e := doc.CreateElementNode("Envelope")
    e.SetNamespace("env", "http://www.w3.org/2003/05/soap-envelope")
        doc.SetRoot(e)

Please bear with me, it's my fist go code :)
Please review and comment!
