### PR TITLE
Fixes for Go 1.4

### DIFF
--- a/gokogiri.go
+++ b/gokogiri.go
@@ -8,8 +8,8 @@ and a simple DOM-like inteface allows for building up documents from scratch.
 package gokogiri
 
 import (
-	"github.com/moovweb/gokogiri/html"
-	"github.com/moovweb/gokogiri/xml"
+	"github.com/ThomsonReutersEikon/gokogiri/html"
+	"github.com/ThomsonReutersEikon/gokogiri/xml"
 )
 
 /*
@@ -27,7 +27,7 @@ ParseXml parses an UTF-8 encoded byte array and returns an xml.XmlDocument. By d
 and suppress errors and warnings. This allows one to liberal in accepting badly-formed documents, but is not standards-compliant.
 
 If the content is not UTF-8 encoded or you want to customize the parsing options, you should call the Parse or ReadFile functions
-found in the github.com/moovweb/gokogiri/xml package. The xml.StrictParsingOption is conveniently provided for standards-compliant
+found in the github.com/ThomsonReutersEikon/gokogiri/xml package. The xml.StrictParsingOption is conveniently provided for standards-compliant
 behaviour.
 */
 func ParseXml(content []byte) (doc *xml.XmlDocument, err error) {

--- a/gokogiri_test.go
+++ b/gokogiri_test.go
@@ -1,7 +1,7 @@
 package gokogiri
 
 import (
-	"github.com/moovweb/gokogiri/help"
+	"github.com/ThomsonReutersEikon/gokogiri/help"
 	"testing"
 )
 

--- a/html/document.go
+++ b/html/document.go
@@ -11,9 +11,9 @@ import "C"
 
 import (
 	"errors"
-	"github.com/moovweb/gokogiri/help"
-	. "github.com/moovweb/gokogiri/util"
-	"github.com/moovweb/gokogiri/xml"
+	"github.com/ThomsonReutersEikon/gokogiri/help"
+	. "github.com/ThomsonReutersEikon/gokogiri/util"
+	"github.com/ThomsonReutersEikon/gokogiri/xml"
 	//"runtime"
 	"unsafe"
 )

--- a/html/fragment.go
+++ b/html/fragment.go
@@ -5,8 +5,8 @@ import "C"
 import (
 	"bytes"
 	"errors"
-	. "github.com/moovweb/gokogiri/util"
-	"github.com/moovweb/gokogiri/xml"
+	. "github.com/ThomsonReutersEikon/gokogiri/util"
+	"github.com/ThomsonReutersEikon/gokogiri/xml"
 	"unsafe"
 )
 

--- a/html/utils_test.go
+++ b/html/utils_test.go
@@ -2,7 +2,7 @@ package html
 
 import (
 	"fmt"
-	"github.com/moovweb/gokogiri/help"
+	"github.com/ThomsonReutersEikon/gokogiri/help"
 	"io/ioutil"
 	"path/filepath"
 	"strings"

--- a/xml/document.go
+++ b/xml/document.go
@@ -9,9 +9,9 @@ import "C"
 
 import (
 	"errors"
-	"github.com/moovweb/gokogiri/help"
-	. "github.com/moovweb/gokogiri/util"
-	"github.com/moovweb/gokogiri/xpath"
+	"github.com/ThomsonReutersEikon/gokogiri/help"
+	. "github.com/ThomsonReutersEikon/gokogiri/util"
+	"github.com/ThomsonReutersEikon/gokogiri/xpath"
 	"os"
 	"unsafe"
 )

--- a/xml/fragment.go
+++ b/xml/fragment.go
@@ -4,7 +4,7 @@ package xml
 import "C"
 import (
 	"errors"
-	. "github.com/moovweb/gokogiri/util"
+	. "github.com/ThomsonReutersEikon/gokogiri/util"
 	"unsafe"
 )
 

--- a/xml/node.go
+++ b/xml/node.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"sync"
 	"unsafe"
-	. "github.com/moovweb/gokogiri/util"
-	"github.com/moovweb/gokogiri/xpath"
+	. "github.com/ThomsonReutersEikon/gokogiri/util"
+	"github.com/ThomsonReutersEikon/gokogiri/xpath"
 )
 
 var (

--- a/xml/utils_test.go
+++ b/xml/utils_test.go
@@ -3,8 +3,8 @@ package xml
 import (
 	"errors"
 	"fmt"
-	"github.com/moovweb/gokogiri/help"
-	"github.com/moovweb/gokogiri/xpath"
+	"github.com/ThomsonReutersEikon/gokogiri/help"
+	"github.com/ThomsonReutersEikon/gokogiri/xpath"
 	"io/ioutil"
 	"path/filepath"
 	"strings"

--- a/xpath/expression.go
+++ b/xpath/expression.go
@@ -32,7 +32,7 @@ char *check_xpath_syntax(const char *xpath) {
 */
 import "C"
 import "unsafe"
-import . "github.com/moovweb/gokogiri/util"
+import . "github.com/ThomsonReutersEikon/gokogiri/util"
 
 //import "runtime"
 import "errors"

--- a/xpath/util.go
+++ b/xpath/util.go
@@ -14,7 +14,7 @@ import "C"
 
 import "unsafe"
 import "reflect"
-import . "github.com/moovweb/gokogiri/util"
+import . "github.com/ThomsonReutersEikon/gokogiri/util"
 
 //export go_resolve_variables
 func go_resolve_variables(ctxt unsafe.Pointer, name, ns *C.char) (ret C.xmlXPathObjectPtr) {

--- a/xpath/util_test.go
+++ b/xpath/util_test.go
@@ -1,7 +1,7 @@
 package xpath
 
 import "testing"
-import "github.com/moovweb/gokogiri/help"
+import "github.com/ThomsonReutersEikon/gokogiri/help"
 
 func CheckXmlMemoryLeaks(t *testing.T) {
 	// LibxmlCleanUpParser() should only be called once during the lifetime of the

--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -46,8 +46,9 @@ import "runtime"
 import "errors"
 
 type XPath struct {
-	ContextPtr *C.xmlXPathContext
-	ResultPtr  *C.xmlXPathObject
+	ContextPtr    *C.xmlXPathContext
+	ResultPtr     *C.xmlXPathObject
+	VariableScope VariableScope
 }
 
 type XPathObjectType int
@@ -208,8 +209,9 @@ func (xpath *XPath) ResultAsBoolean() (val bool, err error) {
 
 // Add a variable resolver.
 func (xpath *XPath) SetResolver(v VariableScope) {
-	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
-	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
+	xpath.VariableScope = v
+	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.VariableScope))
+	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.VariableScope))
 }
 
 // SetContextPosition sets the internal values needed to

--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -41,7 +41,7 @@ int getXPathObjectType(xmlXPathObject* o) {
 import "C"
 
 import "unsafe"
-import . "github.com/moovweb/gokogiri/util"
+import . "github.com/ThomsonReutersEikon/gokogiri/util"
 import "runtime"
 import "errors"
 


### PR DESCRIPTION
Two separate fixes for Go 1.4. It isn't safe to pass a pointer into a function's stack since 1.3, but this seems to blow up much more often in 1.4, maybe because the stack is smaller, so is more likely to be moved.

The xpath commit fixes a test failure in `TestEvalVariableExpr`. The serialize commit has it's own test.

Details of the general problem here: https://github.com/golang/go/issues/8310