### PR TITLE
Fixes for Go 1.4

### DIFF
--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -46,8 +46,9 @@ import "runtime"
 import "errors"
 
 type XPath struct {
-	ContextPtr *C.xmlXPathContext
-	ResultPtr  *C.xmlXPathObject
+	ContextPtr    *C.xmlXPathContext
+	ResultPtr     *C.xmlXPathObject
+	VariableScope VariableScope
 }
 
 type XPathObjectType int
@@ -208,8 +209,9 @@ func (xpath *XPath) ResultAsBoolean() (val bool, err error) {
 
 // Add a variable resolver.
 func (xpath *XPath) SetResolver(v VariableScope) {
-	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
-	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
+	xpath.VariableScope = v
+	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.VariableScope))
+	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.VariableScope))
 }
 
 // SetContextPosition sets the internal values needed to


### PR DESCRIPTION
Two separate fixes for Go 1.4. It isn't safe to pass a pointer into a function's stack since 1.3, but this seems to blow up much more often in 1.4, maybe because the stack is smaller, so is more likely to be moved.

The xpath commit fixes a test failure in `TestEvalVariableExpr`. The serialize commit has it's own test.

Details of the general problem here: https://github.com/golang/go/issues/8310

Replaces #78 
