### PR TITLE
xpath/util: go_can_resolve_function -> possible  nil pointer dereference

### DIFF
--- a/xpath/util.go
+++ b/xpath/util.go
@@ -111,6 +111,9 @@ func go_can_resolve_function(ctxt unsafe.Pointer, name, ns *C.char) (ret C.int) 
 	function := C.GoString(name)
 	namespace := C.GoString(ns)
 	context := (*VariableScope)(ctxt)
+	if *context == nil {
+		return C.int(0)
+	}
 	if (*context).IsFunctionRegistered(function, namespace) {
 		return C.int(1)
 	}


### PR DESCRIPTION
If the context is nil then it led to a nil pointer dereference instead of returning that the function doesn't exist. 

The bug could be reproduced by calling : 
 doc.Root().EvalXPath("unkown-function(//xpath-expression)", nil)

According to the comments for EvalXPath nil is a valid value tho.

Although I am not sure if there should be other functions to be found, at least now i get a "function not found" error instead of an exception.
