### PR TITLE
Fix undefined behavior due to XPath.SetResolver taking address of GC-able interface

### DIFF
--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -46,8 +46,9 @@ import "runtime"
 import "errors"
 
 type XPath struct {
-	ContextPtr *C.xmlXPathContext
-	ResultPtr  *C.xmlXPathObject
+	ContextPtr    *C.xmlXPathContext
+	ResultPtr     *C.xmlXPathObject
+	variableScope VariableScope
 }
 
 type XPathObjectType int
@@ -208,8 +209,9 @@ func (xpath *XPath) ResultAsBoolean() (val bool, err error) {
 
 // Add a variable resolver.
 func (xpath *XPath) SetResolver(v VariableScope) {
-	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
-	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
+	xpath.variableScope = v
+	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.variableScope))
+	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&xpath.variableScope))
 }
 
 // SetContextPosition sets the internal values needed to


### PR DESCRIPTION
XPath.GetResolver takes address of it VariableScope interface parameter and passes that to cgo function for storage in non-GC memory - if this interface is collected by the GC before XPath is evaluated, SIGSEGV or other bad things can occur. This PR stores the VariableScope interface in the XPath struct.
