### PR TITLE
Make gokogiri compile with go 1.6

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -8,9 +8,13 @@ package mem
 */
 import "C"
 
-const LIBXML_VERSION = C.LIBXML_DOTTED_VERSION
+const (
+	LIBXML_VERSION         = C.LIBXML_DOTTED_VERSION
+	LIBXML_NUMERIC_VERSION = C.LIBXML_VERSION
+)
 
 func init() {
+	C.xmlCheckVersion(LIBXML_NUMERIC_VERSION)
 	C.libxmlGoInit()
 }
 

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -2,12 +2,7 @@ package mem
 
 import "testing"
 
-const EXPECTED_VERSION = "2.7.8"
-
 func TestLibxml(t *testing.T) {
-	if LIBXML_VERSION != EXPECTED_VERSION {
-		t.Fatal("Invalid libxml version got:", LIBXML_VERSION, "expected", EXPECTED_VERSION)
-	}
 	if AllocSize() != 0 {
 		t.Fatal(AllocSize(), "remaining allocations")
 	}

--- a/xml/helper.c
+++ b/xml/helper.c
@@ -4,7 +4,7 @@
 //internal callback functions
 int xml_write_callback(void *ctx, char *buffer, int len) {
 	if (len > 0) {
-		xmlNodeWriteCallback(ctx, buffer, len);
+		xmlNodeWriteCallback(buffer, len);
 	}
   	return len;
 }
@@ -129,14 +129,14 @@ int xmlNodePtrCheck(void *node) {
 	return 1;
 }
 
-int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options) {
+int xmlSaveNode(void *node, void *encoding, int options) {
 	xmlSaveCtxtPtr savectx;
 	const char *c_encoding = (char*)encoding;
 
 	savectx = xmlSaveToIO(
 	      (xmlOutputWriteCallback)xml_write_callback,
 	      (xmlOutputCloseCallback)close_callback,
-	      wbuffer,
+	      NULL,
 	      encoding,
 	      options
 	  );

--- a/xml/helper.c
+++ b/xml/helper.c
@@ -97,17 +97,17 @@ xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *ur
 	return tmpRoot;
 }
 
-void xmlSetContent(void *gonode, void *n, void *content) {
+void xmlSetContent(void *n, char *content) {
 	xmlNode *node = (xmlNode*)n;
 	xmlNode *child = node->children;
 	xmlNode *next = NULL;
-	unsigned char *encoded = xmlEncodeSpecialChars(node->doc, content);
+	unsigned char *encoded = xmlEncodeSpecialChars(node->doc, (xmlChar*)content);
 	if (encoded) {
 		while (child) {
 			next = child->next ;
 			xmlUnlinkNode(child);
 			//xmlFreeNode(child);
-			xmlUnlinkNodeCallback(child, gonode);
+			xmlUnlinkNodeCallback(child);
 			child = next ;
 	  	}
 	  	xmlNodeSetContent(node, (xmlChar*)encoded);

--- a/xml/helper.h
+++ b/xml/helper.h
@@ -15,7 +15,7 @@ xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *ur
 int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options);
 void xmlRemoveDefaultNamespace(xmlNode *node);
 
-void xmlSetContent(void *gonode, void *node, void *content);
+void xmlSetContent(void *node, char *content);
 
 xmlDoc* newEmptyXmlDoc();
 xmlElementType getNodeType(xmlNode *node);
@@ -25,7 +25,7 @@ void xmlFreeChars(char *buffer);
 int xmlUnlinkNodeWithCheck(xmlNode *node);
 int xmlNodePtrCheck(void *node);
 void xmlNodeWriteCallback(void *buffer, void *data, int data_len);
-void xmlUnlinkNodeCallback(void *nodePtr, void *gonodePtr);
+void xmlUnlinkNodeCallback(void *nodePtr);
 
 typedef struct XmlBufferContext {
 	void *obj;

--- a/xml/helper.h
+++ b/xml/helper.h
@@ -12,7 +12,7 @@
 xmlDoc* xmlParse(void *buffer, int buffer_len, void *url, void *encoding, int options, void *error_buffer, int errror_buffer_len);
 xmlNode* xmlParseFragment(void* doc, void *buffer, int buffer_len, void *url, int options, void *error_buffer, int error_buffer_len);
 xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *url, void *encoding, int options, void *error_buffer, int error_buffer_len);
-int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options);
+int xmlSaveNode(void *node, void *encoding, int options);
 void xmlRemoveDefaultNamespace(xmlNode *node);
 
 void xmlSetContent(void *node, char *content);
@@ -24,7 +24,7 @@ char *htmlDocDumpToString(xmlDoc *doc, int format);
 void xmlFreeChars(char *buffer);
 int xmlUnlinkNodeWithCheck(xmlNode *node);
 int xmlNodePtrCheck(void *node);
-void xmlNodeWriteCallback(void *buffer, void *data, int data_len);
+void xmlNodeWriteCallback(void *data, int data_len);
 void xmlUnlinkNodeCallback(void *nodePtr);
 
 typedef struct XmlBufferContext {

--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -208,8 +208,9 @@ func (xpath *XPath) ResultAsBoolean() (val bool, err error) {
 
 // Add a variable resolver.
 func (xpath *XPath) SetResolver(v VariableScope) {
-	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
-	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
+	SetScope(unsafe.Pointer(xpath.ContextPtr), v)
+	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(xpath.ContextPtr))
+	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(xpath.ContextPtr))
 }
 
 // SetContextPosition sets the internal values needed to
@@ -234,6 +235,7 @@ func (xpath *XPath) GetContextPosition() (position, size int) {
 
 func (xpath *XPath) Free() {
 	if xpath.ContextPtr != nil {
+		ClearScope(unsafe.Pointer(xpath.ContextPtr))
 		C.xmlXPathFreeContext(xpath.ContextPtr)
 		xpath.ContextPtr = nil
 	}


### PR DESCRIPTION
In Go 1.6 it is basically forbidden to pass a Go pointer to Go functions that are used as callbacks from C.

Fix this by funneling those pointers through global variables.

Fixes #92 