### PR TITLE
Fix compilation incompatibility with go1.12

### DIFF
--- a/xml/document.go
+++ b/xml/document.go
@@ -327,7 +327,7 @@ func (document *XmlDocument) CreateTextNode(data string) (text *TextNode) {
 	dataPtr := unsafe.Pointer(&dataBytes[0])
 	nodePtr := C.xmlNewText((*C.xmlChar)(dataPtr))
 	if nodePtr != nil {
-		nodePtr.doc = (*_Ctype_struct__xmlDoc)(document.DocPtr())
+		nodePtr.doc = (*C.xmlDoc)(document.DocPtr())
 		text = NewNode(unsafe.Pointer(nodePtr), document).(*TextNode)
 	}
 	return


### PR DESCRIPTION
Updating ctypestruct to the new convention c.struct
to make it works with go1.12 and low-architectures (arm based)